### PR TITLE
Return duration as `Infinity` for live controls

### DIFF
--- a/red5pro-jwplayer-provider.js
+++ b/red5pro-jwplayer-provider.js
@@ -41,7 +41,7 @@
         if (event.type === 'Subscribe.Time.Update') {
           this.trigger('time', {
             position: event.data.time,
-            duration: event.data.time
+            duration: Infinity
           })
           return
         } else if (event.type === 'Subscribe.InvalidName') {


### PR DESCRIPTION
JW Player changes the controls to live mode when duration is Infinity. When a stream has a finite duration it is treated as a seekable VOD.